### PR TITLE
Require Module::CoreList v2.31_01

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -46,7 +46,7 @@ version = 0.77
 ; Core from v5.8.8
 Test::Builder::Tester = 0
 ; Core from v5.8.9
-Module::CoreList = 0
+Module::CoreList = 2.31_01
 
 [MetaNoIndex]
 directory = t/08-_get_packages_not_indexed


### PR DESCRIPTION
Hi Yasutaka,

I noticed that you're using Module::CoreList->removed_from(), but removed_from() was only added to Module::CoreList with version 2.31_01: https://metacpan.org/source/BINGOS/Module-CoreList-2.91/Changes.

The commit associated with the pull request fixes the minimum required version for Module::CoreList accordingly. Thank you for considering it!
