### PR TITLE
Fix minor grammatical error in error message

### DIFF
--- a/lib/Test/Kwalitee/Extra.pm
+++ b/lib/Test/Kwalitee/Extra.pm
@@ -64,7 +64,7 @@ sub _pmu_error_desc
 	}
 	$error   ||= q{This distribution uses a module or a dist that's not listed as a prerequisite.};
 	$remedy  ||= q{List all used modules in META.yml requires};
-	$berror  ||= q{This distribution uses a module or a dist in it's test suite that's not listed as a build prerequisite.};
+	$berror  ||= q{This distribution uses a module or a dist in its test suite that's not listed as a build prerequisite.};
 	$bremedy ||= q{List all modules used in the test suite in META.yml build_requires};
 
 	return ($error, $remedy, $berror, $bremedy);

--- a/t/prereq_matches_use_info.pl
+++ b/t/prereq_matches_use_info.pl
@@ -9,7 +9,7 @@ foreach my $val (@$ref) {
 }
 $error   ||= q{This distribution uses a module or a dist that's not listed as a prerequisite.};
 $remedy  ||= q{List all used modules in META.yml requires};
-$berror  ||= q{This distribution uses a module or a dist in it's test suite that's not listed as a build prerequisite.};
+$berror  ||= q{This distribution uses a module or a dist in its test suite that's not listed as a build prerequisite.};
 $bremedy ||= q{List all modules used in the test suite in META.yml build_requires};
 
 return ($error, $remedy, $berror, $bremedy);


### PR DESCRIPTION
The possessive of "it" is "its", not "it's".

This is change is intended to be helpful.  Any comments or questions are more than welcome.