### PR TITLE
Only search existing directories

### DIFF
--- a/lib/Test/Kwalitee/Extra.pm
+++ b/lib/Test/Kwalitee/Extra.pm
@@ -279,10 +279,13 @@ sub _get_packages_not_indexed
 		};
 
 		foreach my $directory (@{$no_index->{'directory'}}) {
-			File::Find::find(
-				$filter_pm_files,
-				File::Spec->catdir($distdir, $directory),
-			);
+			my $no_meta_directory = File::Spec->catdir($distdir, $directory);
+			if(-d $no_meta_directory) {
+				File::Find::find(
+					$filter_pm_files,
+					$no_meta_directory,
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi!

This change makes File::Find only search in existing directories. This makes it possible to name all possible directories in [MetaNoIndex] in a Dist::Zilla plugin bundle without generating warnings if a particular directory is missing in a distribution.
