### PR TITLE
replace MetaCPAN::API::Tiny to MetaCPAN::Client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Or mitigate wait by tentative failures to reduce retry counts like
 
 # INDICATORS
 
-In [Module::CPANTS::Analyse](https://metacpan.org/pod/Module::CPANTS::Analyse), `prereq_matches_use` requires CPANTS DB setup by [Module::CPANTS::ProcessCPAN](https://metacpan.org/pod/Module::CPANTS::ProcessCPAN). `is_prereq` really requires information of prereq of other modules but `prereq_matches_use` only needs mappings between modules and dists. So, this module query the mappings to MetaCPAN by using [MetaCPAN::API::Tiny](https://metacpan.org/pod/MetaCPAN::API::Tiny).
+In [Module::CPANTS::Analyse](https://metacpan.org/pod/Module::CPANTS::Analyse), `prereq_matches_use` requires CPANTS DB setup by [Module::CPANTS::ProcessCPAN](https://metacpan.org/pod/Module::CPANTS::ProcessCPAN). `is_prereq` really requires information of prereq of other modules but `prereq_matches_use` only needs mappings between modules and dists. So, this module query the mappings to MetaCPAN by using [MetaCPAN::Client](https://metacpan.org/pod/MetaCPAN::Client).
 
 Recently, [Module::CPANTS::Analyse](https://metacpan.org/pod/Module::CPANTS::Analyse) has been changed much. For actual available indicators, please consult `Module::CPANTS::Kwalitee::*` documentation. For default configuration, indicators are treated as follows:
 
@@ -170,7 +170,7 @@ Yasutaka ATARASHI <yakex@cpan.org>
 
 # COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2015 by Yasutaka ATARASHI.
+This software is copyright (c) 2017 by Yasutaka ATARASHI.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/dist.ini
+++ b/dist.ini
@@ -9,7 +9,7 @@ version = v0.3.1
 -remove = Test::Kwalitee::Extra
 
 [Prereqs / RuntimeRequires]
-MetaCPAN::API::Tiny = 0
+MetaCPAN::Client = 0
 ; 0.85 depends on renamed module, so can't check easily
 ; 0.87 fixes 2 indicator bugs
 Module::CPANTS::Analyse = 0.87


### PR DESCRIPTION
MetaCPAN::API::Tiny is DEPRECATED and it does't work now.

```
$ perl -MDDP -MMetaCPAN::API::Tiny -e 'my $result = MetaCPAN::API::Tiny->new->module('MetaCPAN::API'); p $result'
Failed to fetch 'http://api.metacpan.org/v0/module/MetaCPAN::API': Gone at -e line 1.
```

It seems that MetaCPAN::API::Tiny uses the v0 version of MetaCPAN API,
but the v0 version has already gone.

``` plain
$ curl -I http://api.metacpan.org/v0/module/MetaCPAN::API
HTTP/1.1 410 Gone
Server: Varnish
Retry-After: 0
Content-Type: text/html
Content-Length: 557
Accept-Ranges: bytes
Date: Sat, 10 Jun 2017 10:06:47 GMT
Via: 1.1 varnish
Connection: close
X-Served-By: cache-sjc3143-SJC
X-Cache: MISS
X-Cache-Hits: 0
X-Timer: S1497089207.346551,VS0,VE0
```

The latest version of MetaCPAN API is v1. ([API-docs](https://github.com/metacpan/metacpan-api/blob/b22b404cb855d7540e7436e37ba7383cbad047b6/docs/API-docs.md))
Test::Kwalitee::Extra should upgrade the API version.